### PR TITLE
add sharded data parallel all gather time estimation

### DIFF
--- a/llm_analysis/constant.py
+++ b/llm_analysis/constant.py
@@ -32,6 +32,7 @@ FLOPS_EFFICIENCY = (
 HBM_MEMORY_EFFICIENCY = 1  # GPU HBM memory efficiency
 INTRA_NODE_MEMORY_EFFICIENCY = 1.0  # intra-node (nvlink) memory efficiency
 INTER_NODE_MEMORY_EFFICIENCY = 1.0  # inter-node memory efficiency
+INTRA_NODE_ALLTOALL_EFFICIENCY = 1.0  # intra-node alltoall efficiency
 
 NUM_GPUS_PER_NODE = 8  # number of GPUs per node
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -61,11 +61,12 @@ def test_training_megatron_lm_1():
         activation_recomputation=activation_recomputation,
     )
 
-    assert within_range(summary_dict["total_training_latency"] / 3600 / 24, 84,
-                        TOLERANCE)
+    assert within_range(
+        summary_dict["total_training_latency_using_flops"] / 3600 / 24, 84,
+        TOLERANCE)
 
     assert (_latency_to_string(
-        summary_dict["total_training_latency"]) == "84.82 days")
+        summary_dict["total_training_latency_using_flops"]) == "84.82 days")
 
     assert _num_to_string(summary_dict["num_params_total"]) == "162.58 G"
 
@@ -107,8 +108,9 @@ def test_training_megatron_lm_2():
         activation_recomputation=activation_recomputation,
     )
 
-    assert within_range(summary_dict["total_training_latency"] / 3600 / 24, 23,
-                        TOLERANCE)
+    assert within_range(
+        summary_dict["total_training_latency_using_flops"] / 3600 / 24, 23,
+        TOLERANCE)
 
 
 # megatron-lm paper https://arxiv.org/abs/2104.04473 Table 2
@@ -149,8 +151,9 @@ def test_training_megatron_lm_3():
             activation_recomputation),
     )
 
-    assert within_range(summary_dict["total_training_latency"] / 3600 / 24,
-                        156, TOLERANCE)
+    assert within_range(
+        summary_dict["total_training_latency_using_flops"] / 3600 / 24, 156,
+        TOLERANCE)
 
 
 # megatron-lm paper https://arxiv.org/abs/2104.04473 Table 2
@@ -192,8 +195,9 @@ def test_training_zero3_1():
         ds_zero=DSZeRO.STAGE_3,
     )
 
-    assert within_range(summary_dict["total_training_latency"] / 3600 / 24, 90,
-                        TOLERANCE)
+    assert within_range(
+        summary_dict["total_training_latency_using_flops"] / 3600 / 24, 90,
+        TOLERANCE)
 
 
 # megatron-lm paper https://arxiv.org/abs/2104.04473 Table 2
@@ -234,8 +238,9 @@ def test_training_zero3_2():
         ds_zero=DSZeRO.STAGE_3,
     )
 
-    assert within_range(summary_dict["total_training_latency"] / 3600 / 24,
-                        136, TOLERANCE)
+    assert within_range(
+        summary_dict["total_training_latency_using_flops"] / 3600 / 24, 136,
+        TOLERANCE)
 
 
 # deepspeed megatron mt-nlg-530b paper https://arxiv.org/abs/2201.11990
@@ -315,8 +320,10 @@ def test_training_mt_nlg_2():
         total_num_tokens=total_num_tokens,
         activation_recomputation=activation_recomputation,
         ds_zero=DSZeRO.STAGE_3,
-    )
+        flash_attn=False)
 
-    assert within_range(summary_dict["latency_per_iter"], 49.98, TOLERANCE)
+    assert within_range(summary_dict["latency_per_iter_using_flops"], 50.2,
+                        TOLERANCE)
 
-    assert _latency_to_string(summary_dict["latency_per_iter"]) == "49.98 s"
+    assert _latency_to_string(
+        summary_dict["latency_per_iter_using_flops"]) == "49.98 s"


### PR DESCRIPTION
When using fsdp shard_grad_op and full_shard, model weights are unsharded through allgather before being used for execution. This PR adds the time estimation of the all gather. If the all gather time > layer compute time, all gather time cannot be fully overlapped with compute. The time estimation relies on intra node and inter node memory bandwidth efficiency, which depends on the size of the data to transfer. 0.8 is a good estimation for data size > 128MB. for small data size, set the efficiency to a lower number.